### PR TITLE
feat: adds class methods without function keyword

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,9 @@
         }
     ],
     "require": {
-        "php": "^7.2"
+        "php": "^7.2",
+        "pre/standard": "dev-master",
+        "yay/yay": "dev-composable-expanders"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^2.15",
@@ -65,5 +67,11 @@
         "pest": "Run the pest tests against himself.",
         "insights": "Run the phpinsights tests.",
         "tests": "Run all tests."
+    },
+    "repositories": {
+        "packagist": {
+            "type": "composer",
+            "url": "https://repo.packagist.org"
+        }
     }
 }

--- a/engine/class-methods-without-function-keyword.yay
+++ b/engine/class-methods-without-function-keyword.yay
@@ -4,10 +4,10 @@ $(macro: recursion) {
     (
     $(optional(\Pre\Standard\Parser\arguments()))
     )
-    $(optional(chain(token(':'), \Pre\Standard\Parser\type())) as type)
+    $(optional(\Pre\Standard\Parser\returnType()))
     $(between(token('{'), layer(), token('}')) as body)
 } >> {
-    $(visibilityModifiers) function $(name) ($$(\Pre\Standard\Expander\arguments($(arguments)))) $$(\Pre\Standard\Expander\type($(type)))
+    $$(\Pre\Standard\Expander\visibilityModifiers($(visibilityModifiers))) function $(name) ($$(\Pre\Standard\Expander\arguments($(arguments)))) $$(\Pre\Standard\Expander\returnType($(returnType)))
     {
         $(body)
     }

--- a/engine/class-methods-without-function-keyword.yay
+++ b/engine/class-methods-without-function-keyword.yay
@@ -1,0 +1,14 @@
+$(macro: recursion) {
+    $(\Pre\Standard\Parser\visibilityModifiers())
+    $(T_STRING as name)
+    (
+    $(optional(\Pre\Standard\Parser\arguments()))
+    )
+    $(optional(chain(token(':'), \Pre\Standard\Parser\type())) as type)
+    $(between(token('{'), layer(), token('}')) as body)
+} >> {
+    $(visibilityModifiers) function $(name) ($$(\Pre\Standard\Expander\arguments($(arguments)))) $$(\Pre\Standard\Expander\type($(type)))
+    {
+        $(body)
+    }
+}

--- a/tests/Integration/class-methods-without-function-keyword.php
+++ b/tests/Integration/class-methods-without-function-keyword.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+declare(plus=1);
+
+$a = new Foo();
+
+test('methods', function () use ($a) {
+    assertEquals('foo', $a->method());
+});
+
+test('final methods', function () use ($a) {
+    assertEquals('foo', $a->methodFinal());
+});
+
+test('return type', function () use ($a) {
+    assertEquals('foo', $a->methodWithReturnType());
+});
+
+test('args', function () use ($a) {
+    $args = ['1', 2, ['a', 'b']];
+    $expected = array_merge($args, ['foo']);
+
+    assertEquals($args + $expected, $a->args(...$args));
+});
+
+
+//@formatter:off
+class Foo
+{
+    public method()
+    {
+        return 'foo';
+    }
+
+    final public methodFinal()
+    {
+        return 'foo';
+    }
+
+    public methodWithReturnType(): string
+    {
+        return 'foo';
+    }
+
+    public args($a, int $b, array $c, $d = 'foo'): array
+    {
+        return [$a, $b, $c, $d];
+    }
+}
+//@formatter:on

--- a/tests/Integration/class-methods-without-function-keyword.php
+++ b/tests/Integration/class-methods-without-function-keyword.php
@@ -4,25 +4,25 @@ declare(strict_types=1);
 
 declare(plus=1);
 
-$a = new Foo();
+$foo = new Foo();
 
-test('methods', function () use ($a) {
-    assertEquals('foo', $a->method());
+test('methods', function () use ($foo) {
+    assertEquals('foo', $foo->method());
 });
 
-test('final methods', function () use ($a) {
-    assertEquals('foo', $a->methodFinal());
+test('final methods', function () use ($foo) {
+    assertEquals('foo', $foo->methodFinal());
 });
 
-test('return type', function () use ($a) {
-    assertEquals('foo', $a->methodWithReturnType());
+test('return type', function () use ($foo) {
+    assertEquals('foo', $foo->methodWithReturnType());
 });
 
-test('args', function () use ($a) {
+test('args', function () use ($foo) {
     $args = ['1', 2, ['a', 'b']];
     $expected = array_merge($args, ['foo']);
 
-    assertEquals($args + $expected, $a->args(...$args));
+    assertEquals($args + $expected, $foo->args(...$args));
 });
 
 


### PR DESCRIPTION
This pull request adds class methods without function keyword. @assertchris could you validate that this is a correct use of the `standard` library`?